### PR TITLE
Skip mise-en-place patch releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ on [Keep a Changelog](https://keepachangelog.com/en/1.1.0), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Skip [mise-en-place](https://mise.jdx.dev) patch releases by default.
 
 ## [1.3.0] - 2025-05-18
 ### Added

--- a/src/default.jsonc
+++ b/src/default.jsonc
@@ -159,8 +159,15 @@
 		{
 			"commitMessageTopic": "mise-en-place",
 			"groupName": "mise-en-place",
+			"matchDepNames": ["jdx/mise"]
+		},
+		{
+			// Currently, mise-en-place has a very frequent release cadence.
+			// Its versioning scheme is date-based instead of SemVer.
+			// Upgrading only to major and minor versions results in a monthly upgrade.
 			"matchDepNames": ["jdx/mise"],
-			"matchUpdateTypes": ["major", "minor"] // Currently, mise-en-place has a very frequent release cadence. Its versioning scheme is date-based instead of SemVer. Upgrading to major and minor versions results in a monthly upgrade.
+			"matchUpdateTypes": ["patch"],
+			"enabled": false
 		},
 		{
 			"commitMessageTopic": "Mock Service Worker",


### PR DESCRIPTION
The current package rule for mise-en-place was incorrect, as it would not disable patch upgrades.