### PR TITLE
Fix the `@tailwindcss/**` package group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Support `@mswjs/**` packages in the `automerge-tooling-patch` configuration.
+- Omit plugins like `@tailwindcss/forms` and `@tailwindcss/typography` from
+  Renovate pull requests that upgrade the
+  main [Tailwind CSS](https://tailwindcss.com) package group.
 
 ## [1.4.0] - 2025-06-15
 ### Added

--- a/src/default.jsonc
+++ b/src/default.jsonc
@@ -270,7 +270,17 @@
 		{
 			"commitMessageTopic": "Tailwind CSS",
 			"groupName": "Tailwind CSS",
-			"matchPackageNames": ["@tailwindcss/**", "tailwindcss"]
+			"matchPackageNames": [
+				"@tailwindcss/browser",
+				"@tailwindcss/cli",
+				"@tailwindcss/node",
+				"@tailwindcss/oxide",
+				"@tailwindcss/oxide-*",
+				"@tailwindcss/postcss",
+				"@tailwindcss/upgrade",
+				"@tailwindcss/vite",
+				"tailwindcss"
+			]
 		},
 		{
 			"commitMessageTopic": "TypeScript",


### PR DESCRIPTION
Plugins such as `@tailwindcss/forms` and `@tailwindcss/typography` follow a separate versioning path. They are not in sync with the main `tailwindcss` package, unlike `@tailwindcss/cli`,
`@tailwindcss/postcss`, and `@tailwindcss/vite`.