### PR TITLE
Use glob pattern syntax in custom managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - Omit the version number in the commit message of type definition upgrades.
 
+### Fixed
+- Use glob pattern syntax in custom managers for
+  remote [Lefthook](https://lefthook.dev) configurations
+  and [mise-en-place](https://mise.jdx.dev).
+
 ## [1.5.1] - 2025-09-09
 ### Changed
 - Group type definitions into a single pull request.
@@ -41,6 +46,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Renovate pull requests that upgrade the
   main [Tailwind CSS](https://tailwindcss.com) package group.
 - Recognise `@next/**` packages when upgrading [Next.js](https://nextjs.org).
+- Rename `fileMatch` to `managerFilePatterns` in custom managers for
+  remote [Lefthook](https://lefthook.dev) configurations
+  and [mise-en-place](https://mise.jdx.dev).
 
 ## [1.4.0] - 2025-06-15
 ### Added

--- a/src/default.jsonc
+++ b/src/default.jsonc
@@ -31,13 +31,20 @@
 	// https://docs.renovatebot.com/modules/manager/regex
 	"customManagers": [
 		{
-			// Support upgrading remote Lefthook configurations.
+			// Support upgrading remote Lefthook configurations in YAML files.
+			// https://lefthook.dev/configuration/index.html
 			// https://lefthook.dev/configuration/remotes.html
 			"customType": "regex",
 			"datasourceTemplate": "github-tags",
-			// language=JSRegexp
-			"managerFilePatterns": ["(^|/)\\.?lefthook(-local)?\\.ya?ml$"],
-			// language=JSRegexp
+			"managerFilePatterns": [
+				"lefthook.{yml,yaml}",
+				"lefthook-local.{yml,yaml}",
+				".lefthook.{yml,yaml}",
+				".lefthook-local.{yml,yaml}",
+				".config/lefthook.{yml,yaml}",
+				".config/lefthook-local.{yml,yaml}"
+			],
+			// language=jsregexp
 			"matchStrings": [
 				"git_url:\\s*(git@github\\.com:|https://github\\.com/)(?<depName>[A-Za-z0-9-]+/[A-Za-z0-9_.-]+)",
 				"ref:\\s*(?<currentValue>\\S+)"
@@ -50,11 +57,17 @@
 			"customType": "regex",
 			"datasourceTemplate": "github-tags",
 			"depNameTemplate": "jdx/mise",
-			// language=JSRegexp
 			"managerFilePatterns": [
-				"(^|/)(\\.config/)?mise(\\.local|/config)?\\.toml$"
+				"mise.*.toml",
+				"mise.toml",
+				"mise/config.toml",
+				".mise.*.toml",
+				".mise.toml",
+				".mise/config.toml",
+				".config/mise.toml",
+				".config/mise/config.toml"
 			],
-			// language=JSRegexp
+			// language=jsregexp
 			"matchStrings": ["min_version\\s*=\\s*['\"](?<currentValue>\\S+)['\"]"],
 			"matchStringsStrategy": "combination"
 		}
@@ -164,7 +177,8 @@
 			// Currently, mise-en-place has a very frequent release cadence.
 			// Its versioning scheme is date-based instead of SemVer.
 			// Upgrading only to major and minor versions results in a monthly upgrade.
-			"allowedVersions": "/^\\d+\\.\\d+\\.0$/",
+			// language=jsregexp
+			"allowedVersions": "/\\d+\\.\\d+\\.0/",
 			"rangeStrategy": "replace"
 		},
 		{


### PR DESCRIPTION
When using regex syntax in `managerFilePatterns`, the regex pattern string must be surrounded by slash characters, e.g. `"/pattern/"`. Otherwise, following commit 957fc12, Renovate recognises it as a glob pattern, which is supported by `managerFilePatterns` unlike `fileMatch`.

This commit adapts `managerFilePatterns` to use glob patterns, as they are easier to read.